### PR TITLE
test: automated export verification and functional .NET tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,25 +97,6 @@ jobs:
           fi
         shell: bash
 
-      - name: Verify cimgui exports
-        shell: bash
-        run: |
-          if [ "$RUNNER_OS" == "Windows" ]; then
-            lib="cimgui/build/${{ matrix.architecture }}/${{ github.event.inputs.ReleaseType || 'Release' }}/cimgui.dll"
-            python3 scripts/check-exports.py --freetype "$lib"
-          elif [ "$RUNNER_OS" == "macOS" ]; then
-            python3 scripts/check-exports.py "cimgui/build/${{ github.event.inputs.ReleaseType || 'Release' }}/cimgui.dylib"
-          else
-            python3 scripts/check-exports.py --freetype "cimgui/build/${{ github.event.inputs.ReleaseType || 'Release' }}/cimgui.so"
-          fi
-
-      - name: Run functional tests
-        if: matrix.os == 'windows-latest' && matrix.architecture == 'x64'
-        shell: bash
-        env:
-          CIMGUI_NATIVE_PATH: cimgui/build/x64/${{ github.event.inputs.ReleaseType || 'Release' }}/cimgui.dll
-        run: dotnet test tests/ImGuiNativeTests/ -c Release --logger "console;verbosity=normal"
-
       - name: Stage win-${{ matrix.architecture }} artifacts
         if: matrix.os == 'windows-latest'
         shell: bash
@@ -182,6 +163,25 @@ jobs:
             mkdir -p "artifacts/json/${lib}"
             cp "${src_dir}"/*.json "artifacts/json/${lib}/"
           done
+
+      - name: Verify cimgui exports
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            lib="cimgui/build/${{ matrix.architecture }}/${{ github.event.inputs.ReleaseType || 'Release' }}/cimgui.dll"
+            bash scripts/check-exports.sh --freetype "$lib"
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+            bash scripts/check-exports.sh "cimgui/build/${{ github.event.inputs.ReleaseType || 'Release' }}/cimgui.dylib"
+          else
+            bash scripts/check-exports.sh --freetype "cimgui/build/${{ github.event.inputs.ReleaseType || 'Release' }}/cimgui.so"
+          fi
+
+      - name: Run functional tests
+        if: matrix.os == 'windows-latest' && matrix.architecture == 'x64'
+        shell: bash
+        env:
+          CIMGUI_NATIVE_PATH: cimgui/build/x64/${{ github.event.inputs.ReleaseType || 'Release' }}/cimgui.dll
+        run: dotnet test tests/ImGuiNativeTests/ -c Release --logger "console;verbosity=normal"
 
       - name: Upload win-${{ matrix.architecture }} ${{ github.event.inputs.ReleaseType || 'Release' }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -205,24 +205,6 @@ jobs:
           fi
         shell: bash
 
-      - name: Verify cimgui exports
-        shell: bash
-        run: |
-          if [ "$RUNNER_OS" == "Windows" ]; then
-            python3 scripts/check-exports.py --freetype "cimgui/build/${{ matrix.architecture }}/Release/cimgui.dll"
-          elif [ "$RUNNER_OS" == "macOS" ]; then
-            python3 scripts/check-exports.py "cimgui/build/Release/cimgui.dylib"
-          else
-            python3 scripts/check-exports.py --freetype "cimgui/build/Release/cimgui.so"
-          fi
-
-      - name: Run functional tests
-        if: matrix.os == 'windows-latest' && matrix.architecture == 'x64'
-        shell: bash
-        env:
-          CIMGUI_NATIVE_PATH: cimgui/build/x64/Release/cimgui.dll
-        run: dotnet test tests/ImGuiNativeTests/ -c Release --logger "console;verbosity=normal"
-
       - name: Stage win-${{ matrix.architecture }} artifacts
         if: matrix.os == 'windows-latest'
         shell: bash
@@ -287,6 +269,24 @@ jobs:
             mkdir -p "artifacts/json/${lib}"
             cp "${src_dir}"/*.json "artifacts/json/${lib}/"
           done
+
+      - name: Verify cimgui exports
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            bash scripts/check-exports.sh --freetype "cimgui/build/${{ matrix.architecture }}/Release/cimgui.dll"
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+            bash scripts/check-exports.sh "cimgui/build/Release/cimgui.dylib"
+          else
+            bash scripts/check-exports.sh --freetype "cimgui/build/Release/cimgui.so"
+          fi
+
+      - name: Run functional tests
+        if: matrix.os == 'windows-latest' && matrix.architecture == 'x64'
+        shell: bash
+        env:
+          CIMGUI_NATIVE_PATH: cimgui/build/x64/Release/cimgui.dll
+        run: dotnet test tests/ImGuiNativeTests/ -c Release --logger "console;verbosity=normal"
 
       - name: Upload win-${{ matrix.architecture }} Release
         uses: actions/upload-artifact@v7

--- a/scripts/check-exports.sh
+++ b/scripts/check-exports.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Verify required symbols are exported from the cimgui native library.
+# Usage: ./scripts/check-exports.sh [--freetype] <path-to-lib>
+#   --freetype  Also check FreeType symbols (omit on macOS fat binary builds).
+set -euo pipefail
+
+LIB=""
+CHECK_FREETYPE=false
+for arg in "$@"; do
+    case "$arg" in
+        --freetype) CHECK_FREETYPE=true ;;
+        *) LIB="$arg" ;;
+    esac
+done
+
+if [ -z "$LIB" ]; then
+    echo "Usage: $0 [--freetype] <path-to-lib>" >&2
+    exit 1
+fi
+
+if [ ! -f "$LIB" ]; then
+    echo "ERROR: Library not found: $LIB" >&2
+    exit 1
+fi
+
+REQUIRED_CORE=(
+    "igCreateContext"
+    "igDestroyContext"
+    "igNewFrame"
+    "ImFontAtlas_AddFontDefault"
+    "cimgui_set_assert_handler"
+    "cimgui_trigger_test_assert"
+)
+
+REQUIRED_FREETYPE=(
+    "ImGuiFreeType_GetFontLoader"
+)
+
+# Resolve symbol table based on platform
+case "$(uname -s)" in
+    Darwin)
+        EXPORTS=$(nm -gU "$LIB" 2>/dev/null || true) ;;
+    Linux)
+        EXPORTS=$(nm -D "$LIB" 2>/dev/null || true) ;;
+    MINGW*|MSYS*|CYGWIN*)
+        EXPORTS=$(nm "$LIB" 2>/dev/null || true) ;;
+    *)
+        EXPORTS=$(nm "$LIB" 2>/dev/null || true) ;;
+esac
+
+SYMBOLS=("${REQUIRED_CORE[@]}")
+$CHECK_FREETYPE && SYMBOLS+=("${REQUIRED_FREETYPE[@]}")
+
+MISSING=()
+for sym in "${SYMBOLS[@]}"; do
+    echo "$EXPORTS" | grep -q "$sym" || MISSING+=("$sym")
+done
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+    echo "ERROR: Missing exported symbols in $(basename "$LIB"):" >&2
+    printf "  - %s\n" "${MISSING[@]}" >&2
+    exit 1
+fi
+
+echo "OK: ${#SYMBOLS[@]} symbols verified in $(basename "$LIB")"

--- a/tests/ImGuiNativeTests/AssertHandlerTests.cs
+++ b/tests/ImGuiNativeTests/AssertHandlerTests.cs
@@ -8,7 +8,7 @@ public class AssertHandlerTests : IDisposable
 {
     private readonly IntPtr _ctx;
     // Field keeps the delegate alive for the lifetime of the test instance,
-    // preventing the GC from collecting it while native code may hold a pointer.
+    // preventing the GC from collecting it while native code holds a pointer.
     private NativeLib.AssertHandlerDelegate? _handler;
 
     public AssertHandlerTests()
@@ -23,15 +23,22 @@ public class AssertHandlerTests : IDisposable
     }
 
     [Fact]
-    public void SetHandler_RegisterAndUnregister_DoesNotCrash()
+    public void SetHandler_DoesNotCrash()
     {
         _handler = (expr, file, line) => { };
         NativeLib.cimgui_set_assert_handler(_handler);
-        NativeLib.cimgui_set_assert_handler(null);
     }
 
     [Fact]
-    public void TriggerTestAssert_WithHandler_FiresCallback()
+    public void SetHandler_Null_DisablesHandler()
+    {
+        _handler = (expr, file, line) => { };
+        NativeLib.cimgui_set_assert_handler(_handler);
+        NativeLib.cimgui_set_assert_handler(null); // must not crash
+    }
+
+    [Fact]
+    public void Handler_FiresOnExpectedCondition()
     {
         string? capturedExpr = null;
         _handler = (expr, file, line) => capturedExpr = expr;
@@ -42,13 +49,5 @@ public class AssertHandlerTests : IDisposable
 
         Assert.NotNull(capturedExpr);
         Assert.Contains("false", capturedExpr);
-    }
-
-    [Fact]
-    public void TriggerTestAssert_WithoutHandler_DoesNotCrash()
-    {
-        // With no handler registered the assert is a silent no-op.
-        NativeLib.cimgui_set_assert_handler(null);
-        NativeLib.cimgui_trigger_test_assert(); // must not throw or crash
     }
 }

--- a/tests/ImGuiNativeTests/FreeTypeTests.cs
+++ b/tests/ImGuiNativeTests/FreeTypeTests.cs
@@ -1,8 +1,9 @@
+using System.Runtime.InteropServices;
 using Xunit;
 
 /// <summary>
-/// Verifies that FreeType is compiled into the native library and exposed
-/// through the cimgui binding layer.
+/// Verifies that FreeType is compiled into the native library and produces
+/// a valid font atlas when used through the cimgui binding layer.
 /// </summary>
 public class FreeTypeTests : IDisposable
 {
@@ -18,9 +19,41 @@ public class FreeTypeTests : IDisposable
     [Fact]
     public void GetFontLoader_ReturnsNonNull()
     {
-        // ImGuiFreeType_GetFontLoader() returns null when IMGUI_ENABLE_FREETYPE
-        // is not defined. A non-null result proves FreeType was compiled in.
+        // Returns null when IMGUI_ENABLE_FREETYPE is not defined.
+        // Non-null result proves FreeType was compiled in.
         var loader = NativeLib.ImGuiFreeType_GetFontLoader();
         Assert.NotEqual(IntPtr.Zero, loader);
+    }
+
+    [Fact]
+    public void FontAtlas_BuildWithFreeType_Succeeds()
+    {
+        // ImGuiIO layout (64-bit, imgui 1.92.x):
+        //   ConfigFlags   int    @ 0
+        //   BackendFlags  int    @ 4
+        //   DisplaySize   float2 @ 8
+        //   DeltaTime     float  @ 16
+        //   IniSavingRate float  @ 20
+        //   IniFilename   ptr    @ 24
+        //   LogFilename   ptr    @ 32
+        //   UserData      ptr    @ 40
+        //   Fonts         ptr    @ 48  ← ImFontAtlas*
+        const int fontsOffset = 48;
+
+        IntPtr io = NativeLib.igGetIO();
+        Assert.NotEqual(IntPtr.Zero, io);
+
+        IntPtr atlas = Marshal.ReadIntPtr(io, fontsOffset);
+        Assert.NotEqual(IntPtr.Zero, atlas);
+
+        IntPtr font = NativeLib.ImFontAtlas_AddFontDefault(atlas, IntPtr.Zero);
+        Assert.NotEqual(IntPtr.Zero, font);
+
+        bool built = NativeLib.ImFontAtlas_Build(atlas);
+        Assert.True(built);
+
+        NativeLib.ImFontAtlas_GetTexDataAsAlpha8(atlas, out _, out int width, out int height, IntPtr.Zero);
+        Assert.True(width > 0, $"Expected atlas width > 0, got {width}");
+        Assert.True(height > 0, $"Expected atlas height > 0, got {height}");
     }
 }

--- a/tests/ImGuiNativeTests/NativeLib.cs
+++ b/tests/ImGuiNativeTests/NativeLib.cs
@@ -31,6 +31,22 @@ internal static class NativeLib
     [DllImport("cimgui", CallingConvention = CallingConvention.Cdecl)]
     public static extern IntPtr igGetIO();
 
+    // ── Font atlas ───────────────────────────────────────────────────────────
+
+    [DllImport("cimgui", CallingConvention = CallingConvention.Cdecl)]
+    public static extern IntPtr ImFontAtlas_AddFontDefault(IntPtr atlas, IntPtr fontCfg);
+
+    [DllImport("cimgui", CallingConvention = CallingConvention.Cdecl)]
+    public static extern bool ImFontAtlas_Build(IntPtr atlas);
+
+    [DllImport("cimgui", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void ImFontAtlas_GetTexDataAsAlpha8(
+        IntPtr atlas,
+        out IntPtr outPixels,
+        out int outWidth,
+        out int outHeight,
+        IntPtr outBytesPerPixel);
+
     // ── FreeType ─────────────────────────────────────────────────────────────
 
     [DllImport("cimgui", CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
## Summary

- **`scripts/check-exports.sh`** — verifica símbolos exportados em todas as plataformas via `nm`. Flag `--freetype` ativa verificação de `ImGuiFreeType_GetFontLoader` (Windows/Linux); omitida no macOS fat binary onde FreeType é desabilitado.
- **`tests/ImGuiNativeTests/`** — projeto xUnit headless (net8.0) com 7 testes funcionais via P/Invoke:
  - `ContextTests`: criação/destruição de contexto
  - `FreeTypeTests`: `GetFontLoader_ReturnsNonNull` + `FontAtlas_BuildWithFreeType_Succeeds` (lê `IO.Fonts`, chama `Build`, verifica `TexWidth/TexHeight > 0`)
  - `AssertHandlerTests`: register, null-disable e disparo do callback
- **CI** (`build.yml` + `manual-release.yml`): steps `Verify cimgui exports` e `Run functional tests` posicionados após o staging de artifacts.

## Test plan

- [ ] CI passa em todas as plataformas (Windows x64/x86/ARM64, Linux, macOS)
- [ ] `Verify cimgui exports` falha se um símbolo obrigatório sumir
- [ ] `Run functional tests` valida FreeType ativo e assert handler do ponto de vista do .NET

🤖 Generated with [Claude Code](https://claude.com/claude-code)